### PR TITLE
Run CI on windows, too

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -51,7 +51,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         toolchain: ["stable", "nightly"]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -62,6 +62,11 @@ jobs:
           target: wasm32-unknown-unknown
           toolchain: ${{ matrix.toolchain }}
 
+      - name: Set git to use LF
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
       - uses: actions/checkout@v2
 
       - name: Cargo build

--- a/tests/diff.rs
+++ b/tests/diff.rs
@@ -21,14 +21,15 @@ fn dump<P: AsRef<Path>>(path: P, buf: &[u8]) -> io::Result<()> {
 }
 
 fn run_diff_test<F: FnOnce(&[u8]) -> Vec<u8>>(test_dir: &str, name: &str, test: F) {
-	// FIXME: not going to work on windows?
-	let mut fixture_path = PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/",));
+	let mut fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+	fixture_path.push("tests");
+	fixture_path.push("fixtures");
 	fixture_path.push(test_dir);
 	fixture_path.push(name);
 
-	// FIXME: not going to work on windows?
-	let mut expected_path =
-		PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/expectations/"));
+	let mut expected_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+	expected_path.push("tests");
+	expected_path.push("expectations");
 	expected_path.push(test_dir);
 	expected_path.push(name);
 


### PR DESCRIPTION
This is less of a concern for the production code but more for the test and benchmarking suites. We don't want to break the project for developers on windows.