### PR TITLE
Add test to measure size overhead

### DIFF
--- a/tests/diff.rs
+++ b/tests/diff.rs
@@ -1,10 +1,9 @@
-use parity_wasm::elements;
 use std::{
 	fs,
 	io::{self, Read, Write},
 	path::{Path, PathBuf},
 };
-use wasm_instrument as instrument;
+use wasm_instrument::{self as instrument, parity_wasm::elements};
 use wasmparser::validate;
 
 fn slurp<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {

--- a/tests/overhead.rs
+++ b/tests/overhead.rs
@@ -1,0 +1,73 @@
+use std::{
+	fs::{read, read_dir},
+	path::PathBuf,
+};
+use wasm_instrument::{
+	gas_metering, inject_stack_limiter,
+	parity_wasm::{deserialize_buffer, elements::Module, serialize},
+};
+
+fn fixture_dir() -> PathBuf {
+	let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+	path.push("benches");
+	path.push("fixtures");
+	path
+}
+
+/// Print the overhead of applying gas metering, stack height limiting or both.
+///
+/// Use `cargo test print_overhead -- --nocapture`.
+#[test]
+fn print_size_overhead() {
+	let mut results: Vec<_> = read_dir(fixture_dir())
+		.unwrap()
+		.map(|entry| {
+			let entry = entry.unwrap();
+			let (orig_len, orig_module) = {
+				let bytes = read(&entry.path()).unwrap();
+				let len = bytes.len();
+				let module: Module = deserialize_buffer(&bytes).unwrap();
+				(len, module)
+			};
+			let (gas_metering_len, gas_module) = {
+				let module = gas_metering::inject(
+					orig_module.clone(),
+					&gas_metering::ConstantCostRules::default(),
+					"env",
+				)
+				.unwrap();
+				let bytes = serialize(module.clone()).unwrap();
+				let len = bytes.len();
+				(len, module)
+			};
+			let stack_height_len = {
+				let module = inject_stack_limiter(orig_module, 128).unwrap();
+				let bytes = serialize(module).unwrap();
+				bytes.len()
+			};
+			let both_len = {
+				let module = inject_stack_limiter(gas_module, 128).unwrap();
+				let bytes = serialize(module).unwrap();
+				bytes.len()
+			};
+
+			let overhead = both_len * 100 / orig_len;
+
+			(
+				overhead,
+				format!(
+					"{:30}: orig = {:4} kb, gas_metering = {} %, stack_limiter = {} %, both = {} %",
+					entry.file_name().to_str().unwrap(),
+					orig_len / 1024,
+					gas_metering_len * 100 / orig_len,
+					stack_height_len * 100 / orig_len,
+					overhead,
+				),
+			)
+		})
+		.collect();
+	results.sort_unstable_by(|a, b| b.0.cmp(&a.0));
+	for entry in results {
+		println!("{}", entry.1);
+	}
+}


### PR DESCRIPTION
Added a test that outputs the size overhead introduced by gas and stack height metering. These are the results:
```
many_blocks.wasm              : orig = 1023 kb, gas_metering = 233 %, stack_limiter = 100 %, both = 233 %
multisig.wasm                 : orig =   27 kb, gas_metering = 110 %, stack_limiter = 141 %, both = 151 %
erc721.wasm                   : orig =   13 kb, gas_metering = 108 %, stack_limiter = 137 %, both = 145 %
erc20.wasm                    : orig =    9 kb, gas_metering = 108 %, stack_limiter = 135 %, both = 144 %
trait_erc20.wasm              : orig =   10 kb, gas_metering = 108 %, stack_limiter = 136 %, both = 144 %
dns.wasm                      : orig =   10 kb, gas_metering = 108 %, stack_limiter = 135 %, both = 143 %
erc1155.wasm                  : orig =   26 kb, gas_metering = 111 %, stack_limiter = 128 %, both = 139 %
contract_transfer.wasm        : orig =    7 kb, gas_metering = 113 %, stack_limiter = 122 %, both = 135 %
rand_extension.wasm           : orig =    4 kb, gas_metering = 109 %, stack_limiter = 123 %, both = 132 %
proxy.wasm                    : orig =    3 kb, gas_metering = 108 %, stack_limiter = 122 %, both = 131 %
contract_terminate.wasm       : orig =    1 kb, gas_metering = 109 %, stack_limiter = 119 %, both = 129 %
```

So it ranges from `30%` to `50%` for a combined instrumentation (as used by pallet-contracts). The `many_blocks` is a synthetic contract used in weight benchmarking that creates a maximum amount of basic blocks to establish a worst case with regard to execution speed (not code size). 