### PR TITLE
Use `u64` for gas counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,17 @@ The interface provided to smart contracts will adhere to semver with one excepti
 major version bumps will be backwards compatible with regard to already deployed contracts.
 In other words: Upgrading this pallet will not break pre-existing contracts.
 
+## [v0.3.0]
+
+### Changed
+
+- Use 64bit arithmetic for per-block gas counter
+[#30](https://github.com/paritytech/wasm-instrument/pull/30)
+
 ## [v0.2.0] 2022-06-06
+
+### Changed
+
 - Adjust debug information (if already parsed) when injecting gas metering
 [#16](https://github.com/paritytech/wasm-instrument/pull/16)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-instrument"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.56.1"
 authors = ["Parity Technologies <admin@parity.io>"]
@@ -27,6 +27,7 @@ parity-wasm = { version = "0.45", default-features = false }
 binaryen = "0.12"
 criterion = "0.3"
 diff = "0.1"
+pretty_assertions = "1"
 rand = "0.8"
 wat = "1"
 wasmparser = "0.90"

--- a/src/gas_metering/mod.rs
+++ b/src/gas_metering/mod.rs
@@ -105,7 +105,7 @@ impl Rules for ConstantCostRules {
 /// imported gas metering function.
 ///
 /// The output module imports a function "gas" from the specified module with type signature
-/// [i32] -> []. The argument is the amount of gas required to continue execution. The external
+/// [i64] -> []. The argument is the amount of gas required to continue execution. The external
 /// function is meant to keep track of the total amount of gas used and trap or otherwise halt
 /// execution of the runtime if the gas usage exceeds some allowed limit.
 ///

--- a/src/gas_metering/validation.rs
+++ b/src/gas_metering/validation.rs
@@ -23,10 +23,10 @@ struct ControlFlowNode {
 	first_instr_pos: Option<usize>,
 
 	/// The actual gas cost of executing all instructions in the basic block.
-	actual_cost: u32,
+	actual_cost: u64,
 
 	/// The amount of gas charged by the injected metering instructions within this basic block.
-	charged_cost: u32,
+	charged_cost: u64,
 
 	/// Whether there are any other nodes in the graph that loop back to this one. Every cycle in
 	/// the control flow graph contains at least one node with this flag set.
@@ -68,10 +68,10 @@ impl ControlFlowGraph {
 	}
 
 	fn increment_actual_cost(&mut self, node_id: NodeId, cost: u32) {
-		self.get_node_mut(node_id).actual_cost += cost;
+		self.get_node_mut(node_id).actual_cost += u64::from(cost);
 	}
 
-	fn increment_charged_cost(&mut self, node_id: NodeId, cost: u32) {
+	fn increment_charged_cost(&mut self, node_id: NodeId, cost: u64) {
 		self.get_node_mut(node_id).charged_cost += cost;
 	}
 
@@ -267,9 +267,9 @@ fn validate_graph_gas_costs(graph: &ControlFlowGraph) -> bool {
 	fn visit(
 		graph: &ControlFlowGraph,
 		node_id: NodeId,
-		mut total_actual: u32,
-		mut total_charged: u32,
-		loop_costs: &mut Map<NodeId, (u32, u32)>,
+		mut total_actual: u64,
+		mut total_charged: u64,
+		loop_costs: &mut Map<NodeId, (u64, u64)>,
 	) -> bool {
 		let node = graph.get_node(node_id);
 

--- a/tests/expectations/gas/branch.wat
+++ b/tests/expectations/gas/branch.wat
@@ -1,10 +1,10 @@
 (module
   (type (;0;) (func (result i32)))
-  (type (;1;) (func (param i32)))
+  (type (;1;) (func (param i64)))
   (import "env" "gas" (func (;0;) (type 1)))
   (func $fibonacci_with_break (;1;) (type 0) (result i32)
     (local i32 i32)
-    i32.const 13
+    i64.const 13
     call 0
     block  ;; label = @1
       i32.const 0
@@ -18,7 +18,7 @@
       local.set 1
       i32.const 1
       br_if 0 (;@1;)
-      i32.const 5
+      i64.const 5
       call 0
       local.get 0
       local.get 1

--- a/tests/expectations/gas/call.wat
+++ b/tests/expectations/gas/call.wat
@@ -1,10 +1,10 @@
 (module
   (type (;0;) (func (param i32 i32) (result i32)))
-  (type (;1;) (func (param i32)))
+  (type (;1;) (func (param i64)))
   (import "env" "gas" (func (;0;) (type 1)))
   (func $add_locals (;1;) (type 0) (param $x i32) (param $y i32) (result i32)
     (local i32)
-    i32.const 5
+    i64.const 5
     call 0
     local.get $x
     local.get $y
@@ -13,7 +13,7 @@
     local.get 2
   )
   (func $add (;2;) (type 0) (param i32 i32) (result i32)
-    i32.const 3
+    i64.const 3
     call 0
     local.get 0
     local.get 1

--- a/tests/expectations/gas/ifs.wat
+++ b/tests/expectations/gas/ifs.wat
@@ -1,19 +1,19 @@
 (module
   (type (;0;) (func (param i32) (result i32)))
-  (type (;1;) (func (param i32)))
+  (type (;1;) (func (param i64)))
   (import "env" "gas" (func (;0;) (type 1)))
   (func (;1;) (type 0) (param i32) (result i32)
-    i32.const 2
+    i64.const 2
     call 0
     i32.const 1
     if (result i32)  ;; label = @1
-      i32.const 3
+      i64.const 3
       call 0
       local.get 0
       i32.const 1
       i32.add
     else
-      i32.const 2
+      i64.const 2
       call 0
       local.get 0
       i32.popcnt

--- a/tests/expectations/gas/simple.wat
+++ b/tests/expectations/gas/simple.wat
@@ -1,16 +1,16 @@
 (module
   (type (;0;) (func))
-  (type (;1;) (func (param i32)))
+  (type (;1;) (func (param i64)))
   (import "env" "gas" (func (;0;) (type 1)))
   (func (;1;) (type 0)
-    i32.const 2
+    i64.const 2
     call 0
     i32.const 1
     if  ;; label = @1
-      i32.const 1
+      i64.const 1
       call 0
       loop  ;; label = @2
-        i32.const 2
+        i64.const 2
         call 0
         i32.const 123
         drop
@@ -18,7 +18,7 @@
     end
   )
   (func (;2;) (type 0)
-    i32.const 1
+    i64.const 1
     call 0
     block  ;; label = @1
     end

--- a/tests/expectations/gas/start.wat
+++ b/tests/expectations/gas/start.wat
@@ -1,12 +1,12 @@
 (module
   (type (;0;) (func (param i32 i32)))
   (type (;1;) (func))
-  (type (;2;) (func (param i32)))
+  (type (;2;) (func (param i64)))
   (import "env" "ext_return" (func $ext_return (;0;) (type 0)))
   (import "env" "memory" (memory (;0;) 1 1))
   (import "env" "gas" (func (;1;) (type 2)))
   (func $start (;2;) (type 1)
-    i32.const 4
+    i64.const 4
     call 1
     i32.const 8
     i32.const 4


### PR DESCRIPTION
This is a less complex alternative for #29. Instead of injection multiple gas metering calls for blocks which overflow `u32` we use `u64` for the costs of a block and just fail in case of an overflow. We argue that this will cover all our use cases. You would need at least `2^32` instructions (cost per instruction is still `u32`)  to create an overflow (`2^32 * 2^32 = 2^64`). Programs this large are surely out of scope.

This is a breaking change hence the bump to `0.3.0`. Embeddeders which upgrade to this version need to also make sure to upgrade the parameter of the cost function to `u64`. We argue that this is okay: If the code is able to upgrade to this new instrumentation it would also be able to upgrade the code which provides the new cost function (in addition to the old one) at the same time.