### PR TITLE
Speedup CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -84,29 +84,29 @@ jobs:
           command: build
           args: --no-default-features --target wasm32-unknown-unknown
 
-test:
-  strategy:
-    matrix:
-      os: ["ubuntu_20_64_core", "macos-latest", "windows-latest"]
-  runs-on: ${{ matrix.os }}
-  steps:
-    - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        default: true
+  test:
+    strategy:
+      matrix:
+        os: ["ubuntu_20_64_core", "macos-latest", "windows-latest"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          default: true
 
-    - name: Set git to use LF
-      run: |
-        git config --global core.autocrlf false
-        git config --global core.eol lf
+      - name: Set git to use LF
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
 
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Cargo test
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --all-features
+      - name: Cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-features
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   rustfmt:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu_20_64_core"
     steps:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/checkout@v3
 
-      - name: Cargo fmt
+      - name: Fmt
         uses: actions-rs/cargo@v1
         with:
           toolchain: nightly
@@ -30,7 +30,7 @@ jobs:
           args: --all -- --check
 
   clippy:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu_20_64_core"
     steps:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -38,60 +38,75 @@ jobs:
           profile: minimal
           toolchain: stable
           components: clippy
+          default: true
 
       - uses: actions/checkout@v3
 
-      - name: Cargo clippy
-        uses: actions-rs/cargo@v1
+      - name: Clippy
+        uses: actions-rs/clippy-check@v1
         with:
-          toolchain: stable
-          command: clippy
+          token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-targets --all-features -- -D warnings
 
-  test:
-    strategy:
-      matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        toolchain: ["stable", "nightly"]
-    runs-on: ${{ matrix.os }}
+  build:
+    runs-on: "ubuntu_20_64_core"
     steps:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           target: wasm32-unknown-unknown
-          toolchain: ${{ matrix.toolchain }}
-
-      - name: Set git to use LF
-        run: |
-          git config --global core.autocrlf false
-          git config --global core.eol lf
+          toolchain: stable
+          default: true
 
       - uses: actions/checkout@v3
 
       - name: Cargo build
         uses: actions-rs/cargo@v1
         with:
-          toolchain: ${{ matrix.toolchain }}
           command: build
+
+      - name: Cargo build (std)
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --all-features
 
       - name: Cargo build (no_std)
         uses: actions-rs/cargo@v1
         with:
-          toolchain: ${{ matrix.toolchain }}
           command: build
           args: --no-default-features
 
       - name: Cargo build (wasm)
         uses: actions-rs/cargo@v1
         with:
-          toolchain: ${{ matrix.toolchain }}
           command: build
           args: --no-default-features --target wasm32-unknown-unknown
 
-      - name: Cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          toolchain: ${{ matrix.toolchain }}
-          command: test
-          args: --all-features
+test:
+  strategy:
+    matrix:
+      os: ["ubuntu_20_64_core", "macos-latest", "windows-latest"]
+  runs-on: ${{ matrix.os }}
+  steps:
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        default: true
+
+    - name: Set git to use LF
+      run: |
+        git config --global core.autocrlf false
+        git config --global core.eol lf
+
+    - uses: actions/checkout@v3
+
+    - name: Cargo test
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --all-features
+


### PR DESCRIPTION
* No need to build on nightly: This crate works on stable
* Use larger runners where applicable (linux)
* Only run the tests on macOS and Windows: The rest is OS independent